### PR TITLE
Fixed bzip2 cmake list (for windows + vs2015 build)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif(ZLIB_FOUND)
 
 find_package (BZip2 REQUIRED)
 if (BZIP2_FOUND)
-  include_directories(${BZIP_INCLUDE_DIRS})
+  include_directories(${BZIP2_INCLUDE_DIR})
   SET(LINK_LIBS ${LINK_LIBS} ${BZIP2_LIBRARIES})
 endif (BZIP2_FOUND)
 


### PR DESCRIPTION
Include directories generated by cmake (v3.5) had build errors - bzip2 include dir was specified incorrectly so it wasn't added to projects' include dir.

https://cmake.org/cmake/help/v3.0/module/FindBZip2.html